### PR TITLE
fixed happy coffe text placement on gallery

### DIFF
--- a/css/Gallery.css
+++ b/css/Gallery.css
@@ -7,7 +7,9 @@
 
 /* Code for gallery page starts here. */ 
 
-
+#logo-text {
+  padding-bottom: 28px;
+}
 .gallery-container {
     display: flex;
     flex-direction: column;
@@ -76,6 +78,7 @@ p {
   text-align: center;
   margin: 0;
 }
+
 /* Media query for tablet view (between 960px and 768px) */
 @media screen and (min-width: 768px) and (max-width: 960px) {
   /* Reduce the font size for description text */


### PR DESCRIPTION
added code 
#logo-text {
  padding-bottom: 28px;
}
on my css file, now text next to logo is in line with it